### PR TITLE
[Feat] Account 생성 수정 API 문서 수정

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -37,8 +37,11 @@ include::{snippets}/createAccount/curl-request.adoc[]
 .http-request
 include::{snippets}/createAccount/http-request.adoc[]
 
-.request-fields
-include::{snippets}/createAccount/request-fields.adoc[]
+.request-parts
+include::{snippets}/createAccount/request-parts.adoc[]
+
+.request-parameters
+include::{snippets}/createAccount/request-parameters.adoc[]
 
 .http-response
 include::{snippets}/createAccount/http-response.adoc[]
@@ -60,8 +63,11 @@ include::{snippets}/modifyAccount/request-headers.adoc[]
 .request-path_parameters
 include::{snippets}/modifyAccount/path-parameters.adoc[]
 
-.request-fields
-include::{snippets}/modifyAccount/request-fields.adoc[]
+.request-parts
+include::{snippets}/modifyAccount/request-parts.adoc[]
+
+.request-parameters
+include::{snippets}/modifyAccount/request-parameters.adoc[]
 
 .http-response
 include::{snippets}/modifyAccount/http-response.adoc[]

--- a/back/src/main/java/stackoverflow/domain/account/controller/AccountController.java
+++ b/back/src/main/java/stackoverflow/domain/account/controller/AccountController.java
@@ -48,7 +48,7 @@ public class AccountController {
         return new ResponseEntity(mockResDto, HttpStatus.OK);
     }
 
-    @PatchMapping("/{accountId}")
+    @PostMapping("/{accountId}")
     public ResponseEntity<SingleResDto<String>> accountModify(@PathVariable long accountId,
                                                               @Valid @ModelAttribute PatchAccountReqDto modifyAccountReqDto) {
         modifyAccountReqDto.setPassword(passwordEncoder.encode(modifyAccountReqDto.getPassword()));

--- a/back/src/main/java/stackoverflow/domain/account/dto/PostAccountReqDto.java
+++ b/back/src/main/java/stackoverflow/domain/account/dto/PostAccountReqDto.java
@@ -24,7 +24,6 @@ public class PostAccountReqDto {
             message = "4자 미만에 특수 문자가 없어야 합니다.")
     private String nickname;
 
-    @NotEmpty(message = "프로필 이미지가 있어야합니다.")
     private MultipartFile profile;
 
     public Account toAccount(String profilePath) {

--- a/back/src/test/java/stackoverflow/domain/account/controller/AccountControllerTest.java
+++ b/back/src/test/java/stackoverflow/domain/account/controller/AccountControllerTest.java
@@ -4,10 +4,12 @@ import com.google.gson.Gson;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -21,8 +23,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static stackoverflow.util.ApiDocumentUtils.getRequestPreProcessor;
 import static stackoverflow.util.ApiDocumentUtils.getResponsePreProcessor;
@@ -37,6 +38,9 @@ class AccountControllerTest {
 
     @Autowired
     private Gson gson;
+
+    @Value("${file.img}")
+    private String path;
 
     @Test
     @DisplayName("Account Login_성공")
@@ -92,21 +96,17 @@ class AccountControllerTest {
         String email = "mock2@gmail.com";
         String password = "mock1234";
         String nickname = "moc2";
+        MockMultipartFile file = new MockMultipartFile("profile", "profile", "image/jpeg",
+                "file".getBytes());
 
-
-        PostAccountReqDto postAccountReqDto = new PostAccountReqDto();
-        postAccountReqDto.setEmail(email);
-        postAccountReqDto.setPassword(password);
-        postAccountReqDto.setNickname(nickname);
-
-        String body = gson.toJson(postAccountReqDto);
 
         //when
         ResultActions actions = mockMvc.perform(
-                post("/accounts")
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(body)
+                multipart("/accounts")
+                        .file(file)
+                        .param("email", email)
+                        .param("password", password)
+                        .param("nickname", nickname)
         );
 
         //then
@@ -115,11 +115,16 @@ class AccountControllerTest {
                         "createAccount",
                         getRequestPreProcessor(),
                         getResponsePreProcessor(),
-                        requestFields(
+                        requestParts(
                                 List.of(
-                                        fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
-                                        fieldWithPath("password").type(JsonFieldType.STRING).description("비밀 번호"),
-                                        fieldWithPath("nickname").type(JsonFieldType.STRING).description("이름")
+                                        partWithName("profile").description("프로필 이미지")
+                                )
+                        ),
+                        requestParameters(
+                                List.of(
+                                        parameterWithName("email").description("이메일"),
+                                        parameterWithName("password").description("비밀 번호"),
+                                        parameterWithName("nickname").description("이름")
                                 )
                         ),
                         responseFields(
@@ -169,23 +174,18 @@ class AccountControllerTest {
         long accountId = 1L;
         String nickname = "modi";
         String password = "testModified1234";
-        String profile = "/path/test/modified";
         String jwt = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzYW1wbGUxQHNhbXBsZS5jb20iLCJpZCI6MSwiZX";
+        MockMultipartFile file = new MockMultipartFile("profile", "profile", "image/jpeg",
+                "file".getBytes());
 
-        PatchAccountReqDto patchAccountReqDto = new PatchAccountReqDto();
-        patchAccountReqDto.setNickname(nickname);
-        patchAccountReqDto.setPassword(password);
-        patchAccountReqDto.setProfile(profile);
-
-        String body = gson.toJson(patchAccountReqDto);
 
         //when
         ResultActions actions = mockMvc.perform(
-                patch("/accounts/{accountId}", accountId)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON)
+                multipart("/accounts/{accountId}", accountId)
+                        .file(file)
                         .header("Authorization", jwt)
-                        .content(body)
+                        .param("nickname", nickname)
+                        .param("password", password)
         );
 
 
@@ -203,11 +203,15 @@ class AccountControllerTest {
                                         headerWithName("Authorization").description("JWT")
                                 )
                         ),
-                        requestFields(
+                        requestParts(
                                 List.of(
-                                        fieldWithPath("nickname").type(JsonFieldType.STRING).description("이름"),
-                                        fieldWithPath("password").type(JsonFieldType.STRING).description("비밀 번호"),
-                                        fieldWithPath("profile").type(JsonFieldType.STRING).description("프로필 이미지 경로")
+                                        partWithName("profile").description("프로필 이미지")
+                                )
+                        ),
+                        requestParameters(
+                                List.of(
+                                        parameterWithName("nickname").description("이름"),
+                                        parameterWithName("password").description("비밀 번호")
                                 )
                         ),
                         responseFields(


### PR DESCRIPTION
1. 회원가입 시 프로필 유효성검사를 제거했습니다.
2. Form 요청은 POST, GET 만 가능하다 하여 Account 수정 메서드를 PATCH 에서 POST로 변경하였습니다.